### PR TITLE
Update MediaElch.nuspec

### DIFF
--- a/mediaelch/MediaElch.nuspec
+++ b/mediaelch/MediaElch.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>mediaelch</id>
-        <version>2.8.18</version>
+        <version>2.10.0</version>
         <title>MediaElch</title>
         <authors>bugwelle</authors>
         <owners>sumo300</owners>
@@ -16,9 +16,9 @@
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>MediaElch is a MediaManager for Kodi. Information about Movies, TV Shows, Concerts and Music are stored as nfo files. Fanarts are downloaded automatically from fanart.tv. Using the nfo generator, MediaElch can be used with other MediaCenters as well.</description>
         <summary>Your media manager for movies, tv shows, concerts and music</summary>
-        <releaseNotes>https://mediaelch.github.io/mediaelch-blog/posts/mediaelch-v2.8.18/</releaseNotes>
+        <releaseNotes>https://mediaelch.github.io/mediaelch-blog/posts/mediaelch-v2.10.0/</releaseNotes>
         <language>en-US</language>
-        <tags>media manager movies tv concerts music IMDB scraper Kodi nfo</tags>
+        <tags>media manager movies tv concerts music IMDb scraper Kodi nfo</tags>
     </metadata>
     <files>
         <file src="tools\chocolateyInstall.ps1" target="tools\chocolateyInstall.ps1" />


### PR DESCRIPTION
@sumo300 I wanted to inform you that the ZIP naming changes a bit. We now build with Qt5 _and_ Qt6. The latter is for Windows 10 and later. 

- `MediaElch_win_7_8_Qt5_2.10.0_2023-02-05_20-06_git-master-960303af.zip`
- `MediaElch_win_10_or_later_Qt6_2.10.0_2023-02-05_git-960303af.zip`