### PR TITLE
Updates MediaElch Metadata

### DIFF
--- a/mediaelch/MediaElch.nuspec
+++ b/mediaelch/MediaElch.nuspec
@@ -8,10 +8,10 @@
         <owners>sumo300</owners>
         <licenseUrl>https://github.com/Komet/MediaElch/blob/master/COPYING</licenseUrl>
         <projectUrl>http://www.kvibes.de/en/mediaelch/</projectUrl>
-        <iconUrl>https://raw.githack.com/Komet/MediaElch/master/data/img/MediaElch@2x.png</iconUrl>
+        <iconUrl>https://raw.githack.com/Komet/MediaElch/master/data/img/MediaElch.png</iconUrl>
         <docsUrl>https://mediaelch.github.io/mediaelch-doc/index.html</docsUrl>
         <bugTrackerUrl>https://github.com/Komet/MediaElch/issues</bugTrackerUrl>
-        <packageSourceUrl>hhttps://github.com/sumo300/chocolatey-packages-au</packageSourceUrl>
+        <packageSourceUrl>https://github.com/sumo300/chocolatey-packages-au</packageSourceUrl>
         <projectSourceUrl>https://github.com/Komet/MediaElch</projectSourceUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>MediaElch is a MediaManager for Kodi. Information about Movies, TV Shows, Concerts and Music are stored as nfo files. Fanarts are downloaded automatically from fanart.tv. Using the nfo generator, MediaElch can be used with other MediaCenters as well.</description>


### PR DESCRIPTION
This change will hopefully workaround issues with Chocolatey Community Repository's validator rules while they are fixed.

It also corrects `hhttps` to `https`, in the `packageSourceUrl`.

